### PR TITLE
Revert "fix: obsoletes saltext.elasticsearch8"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires = [
     "python-semantic-release>=7.16.0"
 ]
 build-backend = "setuptools.build_meta"
-obsoletes = ["saltext.elasticsearch8"]
 
 [tool.setuptools_scm]
 write_to = "src/saltext/elasticsearch/version.py"


### PR DESCRIPTION
This reverts commit 5201185d169a47c09cec20c816a66d9977ebc00d.